### PR TITLE
Add "SNS" as a service fixture

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ kinesis = b3f.contrib.pytest.service_fixture("kinesis", scope="class", streams=f
 dynamodb = b3f.contrib.pytest.service_fixture("dynamodb", scope="class", tables=fixtures.DYNAMODB)
 s3 = b3f.contrib.pytest.service_fixture("s3", scope="class", buckets=fixtures.S3)
 lam = b3f.contrib.pytest.service_fixture("lambda", scope="class", lambdas=fixtures.LAMBDA)
+sns = b3f.contrib.pytest.service_fixture("sns", scope="class", topics=fixtures.TOPICS)
 
 
 # Example Usage
@@ -97,6 +98,7 @@ Configuration of a service may be either a list of *names* `List[str]` or a list
 | kinesis  | yes           | yes             |
 | dynamodb |               | yes             |
 | lambda   |               | yes             |
+| sns      | yes           | yes             |
 
 For example, your configuration might look like this:
 
@@ -127,6 +129,17 @@ LAMBDA = [
         "FunctionName": "my_lambda",
         "Runtime": "python3.6",
         "Environment": {"foo": True},
+    }
+]
+
+SNS = [
+    "my-topic-with-default-attrs",
+    {
+        "Name": "my-topic-with-additional-params",
+        "Tags": [{"Key": "key1", "Value": "val1"}],
+        "Attributes": {
+            "DisplayName": "YourSystemIsOnFireTopic",
+        },
     }
 ]
 ```

--- a/boto3_fixtures/contrib/pytest.py
+++ b/boto3_fixtures/contrib/pytest.py
@@ -53,6 +53,7 @@ def moto_fixture(
         "kinesis": moto.mock_kinesis,
         "s3": moto.mock_s3,
         "lambda": moto.mock_lambda,
+        "sns": moto.mock_sns,
     }
 
     ENV = {

--- a/boto3_fixtures/service.py
+++ b/boto3_fixtures/service.py
@@ -1,7 +1,7 @@
 from contextlib import ContextDecorator
 
 import boto3_fixtures as b3f
-from boto3_fixtures import awslambda, dynamodb, kinesis, s3, sqs
+from boto3_fixtures import awslambda, dynamodb, kinesis, s3, sqs, sns
 
 SERVICES = {
     "lambda": awslambda,
@@ -9,6 +9,7 @@ SERVICES = {
     "kinesis": kinesis,
     "s3": s3,
     "sqs": sqs,
+    "sns": sns,
 }
 
 

--- a/boto3_fixtures/service.py
+++ b/boto3_fixtures/service.py
@@ -1,7 +1,7 @@
 from contextlib import ContextDecorator
 
 import boto3_fixtures as b3f
-from boto3_fixtures import awslambda, dynamodb, kinesis, s3, sqs, sns
+from boto3_fixtures import awslambda, dynamodb, kinesis, s3, sns, sqs
 
 SERVICES = {
     "lambda": awslambda,

--- a/boto3_fixtures/sns.py
+++ b/boto3_fixtures/sns.py
@@ -15,15 +15,13 @@ Example:
     >>> sns = b3f.contrib.pytest.service_fixture(sns, topics=TOPICS)
 """
 
-import backoff
 import typing as T
 
+import backoff
 from botocore.exceptions import ClientError
 
 import boto3_fixtures.contrib.boto3
 import boto3_fixtures.utils as utils
-
-TopicList = T.List[T.Union[str, dict]]
 
 
 @backoff.on_exception(backoff.expo, ClientError, max_time=30)
@@ -53,14 +51,12 @@ def destroy_topics(topic_arn_list: T.List[str]):
 
 # --- Service interface ---
 
-def setup(topics: T.Optional[TopicList] = None):
+
+def setup(topics: T.Optional[T.List[T.Union[str, dict]]] = None):
     if topics is None:
         return {"topic_arns": []}
 
-    topic_configs = [
-        {"Name": val} if isinstance(val, str) else val
-        for val in topics
-    ]
+    topic_configs = [{"Name": val} if isinstance(val, str) else val for val in topics]
 
     arns = create_topics(topic_configs)
 

--- a/boto3_fixtures/sns.py
+++ b/boto3_fixtures/sns.py
@@ -1,0 +1,71 @@
+"""
+Module `sns` implements the setup and tear-down of SNS topics via boto3.
+
+Example:
+    >>> import boto3_fixtures as b3f
+    >>> # ... setup `aws` fixture
+    >>>
+    >>> TOPICS = [
+    >>>     "topic-1",
+    >>>     {
+    >>>         "TopicName": "topic-with-attrs",
+    >>>         "Attributes": {"DisplayName": "Topic With Attributes"},
+    >>>     }
+    >>> ]
+    >>> sns = b3f.contrib.pytest.service_fixture(sns, topics=TOPICS)
+"""
+
+import backoff
+import typing as T
+
+from botocore.exceptions import ClientError
+
+import boto3_fixtures.contrib.boto3
+import boto3_fixtures.utils as utils
+
+TopicList = T.List[T.Union[str, dict]]
+
+
+@backoff.on_exception(backoff.expo, ClientError, max_time=30)
+def create_topics(topic_config_list: T.List[dict]) -> T.List[str]:
+    sns = boto3_fixtures.contrib.boto3.client("sns")
+    arns = []
+    for tpc_config in topic_config_list:
+        resp = utils.call(sns.create_topic, **tpc_config)
+
+        def _check_topic(arn):
+            return boto3_fixtures.contrib.boto3.client("sns").get_topic_attributes(
+                TopicArn=arn
+            )
+
+        utils.call(utils.backoff_check, func=lambda: _check_topic(resp["TopicArn"]))
+
+        arns.append(resp["TopicArn"])
+    return arns
+
+
+@backoff.on_exception(backoff.expo, ClientError, max_time=30)
+def destroy_topics(topic_arn_list: T.List[str]):
+    sns = boto3_fixtures.contrib.boto3.client("sns")
+    for arn in topic_arn_list:
+        utils.call(sns.delete_topic, TopicArn=arn)
+
+
+# --- Service interface ---
+
+def setup(topics: T.Optional[TopicList] = None):
+    if topics is None:
+        return {"topic_arns": []}
+
+    topic_configs = [
+        {"Name": val} if isinstance(val, str) else val
+        for val in topics
+    ]
+
+    arns = create_topics(topic_configs)
+
+    return {"topic_arns": arns}
+
+
+def teardown(**kwargs):
+    destroy_topics(kwargs["topic_arns"])

--- a/boto3_fixtures/sns.py
+++ b/boto3_fixtures/sns.py
@@ -75,5 +75,5 @@ def setup(topics: T.List[T.Union[str, dict]] = None):
     return {"topics": arns}
 
 
-def teardown(**kwargs):
-    return destroy_topics(kwargs["topics"])
+def teardown(topics: T.Dict[str, SNSTopic]):
+    return destroy_topics(topics)

--- a/boto3_fixtures/utils.py
+++ b/boto3_fixtures/utils.py
@@ -97,6 +97,7 @@ def environment(
     kinesis_streams: list = [],
     dynamodb_tables: list = [],
     s3_buckets: list = [],
+    sns_topics: list = [],
 ):
     def clean(s):
         return s.upper().replace("-", "_")
@@ -111,6 +112,7 @@ def environment(
         vars.update({clean(q): q for q in sqs_queues})
         vars.update({clean(q): q for q in s3_buckets})
         vars.update({clean(t): t for t in dynamodb_tables})
+        vars.update({clean(tpc): tpc for tpc in sns_topics})
         will_overwrite = list(set(vars.keys()) & set(kwargs.keys()))
         if will_overwrite:
             logging.getLogger().warning(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -78,7 +78,7 @@ def s3_buckets():
 
 
 @pytest.fixture(scope="class")
-def environment(sqs_queues, kinesis_streams, dynamodb_tables, s3_buckets):
+def environment(sqs_queues, kinesis_streams, dynamodb_tables, s3_buckets, sns_topics):
     # Ideally, nothing should have to "spin up" to run this fixture (for example, localstack)
     return b3f.utils.environment(
         fixtures=fixtures.ENV,
@@ -86,6 +86,7 @@ def environment(sqs_queues, kinesis_streams, dynamodb_tables, s3_buckets):
         kinesis_streams=kinesis_streams,
         dynamodb_tables=dynamodb_tables,
         s3_buckets=s3_buckets,
+        sns_topics=sns_topics,
     )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -10,7 +10,7 @@ import boto3_fixtures as b3f
 logger = logging.getLogger()
 
 stack_config = {
-    "services": ["dynamodb", "kinesis", "sqs", "s3", "lambda"],
+    "services": ["dynamodb", "kinesis", "sqs", "s3", "lambda", "sns"],
     "scope": "class",
     "autouse": False,
     "region_name": fixtures.ENV["AWS_DEFAULT_REGION"],
@@ -30,11 +30,18 @@ s3 = b3f.contrib.pytest.service_fixture("s3", scope="class", buckets=fixtures.S3
 lam = b3f.contrib.pytest.service_fixture(
     "lambda", scope="class", lambdas=fixtures.LAMBDA,
 )
+sns = b3f.contrib.pytest.service_fixture("sns", scope="class", topics=fixtures.SNS)
 
 
 @pytest.fixture(scope="class")
 def aws(moto):
     pass
+
+
+def _string_or_key(v, key):
+    if isinstance(v, str):
+        return v
+    return v[key]
 
 
 @pytest.fixture(scope="session", autouse=True)
@@ -52,12 +59,17 @@ def kinesis_streams():
 
 @pytest.fixture(scope="session")
 def sqs_queues():
-    return [q["QueueName"] if isinstance(q, dict) else q for q in fixtures.SQS]
+    return [_string_or_key(q, "QueueName") for q in fixtures.SQS]
 
 
 @pytest.fixture(scope="session")
 def dynamodb_tables():
     return [t["TableName"] for t in fixtures.DYNAMODB]
+
+
+@pytest.fixture(scope="session")
+def sns_topics():
+    return [_string_or_key(tpc, "Name") for tpc in fixtures.SNS]
 
 
 @pytest.fixture(scope="session")

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -37,10 +37,5 @@ LAMBDA = [
 
 SNS = [
     "topic-1",
-    {
-        "Name": "topic-with-tags",
-        "Tags": [
-            {"Key": "tag", "Value": "hello"}
-        ]
-    }
+    {"Name": "topic-with-tags", "Tags": [{"Key": "tag", "Value": "hello"}]},
 ]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -34,3 +34,13 @@ LAMBDA = [
         "Environment": {"test_bool_env_var": True},
     }
 ]
+
+SNS = [
+    "topic-1",
+    {
+        "Name": "topic-with-tags",
+        "Tags": [
+            {"Key": "tag", "Value": "hello"}
+        ]
+    }
+]

--- a/tests/integration/test_fixtures.py
+++ b/tests/integration/test_fixtures.py
@@ -23,3 +23,7 @@ class TestMockWithLocalstack:
     @pytest.mark.usefixtures("lam")
     def test_lambda_fixtures(self, lambda_functions):
         tests.utils.check_lambda_fixtures(lambda_functions)
+
+    @pytest.mark.usefixtures("sns")
+    def test_sns_fixtures(self, sns_topics):
+        tests.utils.check_sns_fixtures(sns_topics)

--- a/tests/unit/test_fixtures.py
+++ b/tests/unit/test_fixtures.py
@@ -22,3 +22,7 @@ class TestMockWithMoto:
     @pytest.mark.usefixtures("lam")
     def test_lambda_fixtures(self, lambda_functions):
         tests.utils.check_lambda_fixtures(lambda_functions)
+
+    @pytest.mark.usefixtures("sns")
+    def test_sns_fixtures(self, sns_topics):
+        tests.utils.check_sns_fixtures(sns_topics)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -52,5 +52,4 @@ def check_sns_fixtures(sns_topics):
     client = boto3.client("sns")
     resp = utils.call(utils.backoff_check, func=lambda: client.list_topics())
     topic_names = [tpc["TopicArn"].rsplit(":", 1)[-1] for tpc in resp["Topics"]]
-    assert len(topic_names) == len(sns_topics)
     assert set(topic_names) == set(sns_topics)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -46,3 +46,11 @@ def check_lambda_fixtures(lambda_functions):
     lambda_names = {lam["FunctionName"]: lam for lam in resp["Functions"]}
     for lam in lambda_functions:
         assert lam["FunctionName"] in lambda_names
+
+
+def check_sns_fixtures(sns_topics):
+    client = boto3.client("sns")
+    resp = utils.call(utils.backoff_check, func=lambda: client.list_topics())
+    topic_names = [tpc["TopicArn"].rsplit(":", 1)[-1] for tpc in resp["Topics"]]
+    assert len(topic_names) == len(sns_topics)
+    assert set(topic_names) == set(sns_topics)


### PR DESCRIPTION
The developer may create multiple SNS topics through the "SNS" service fixture. Topics to create are specified in the "topics" list in the call to `service_fixture`. Each list entry may be either the topic name as a string, or a dict containing kwargs to the underlying boto3 `create_topic` call.

```py
import boto3_fixtures as b3f

# ... setup of `aws` fixture

TOPICS = [
    "my-topic-1",
    {
        "Name": "my-topic-with-tags", 
        "Tags": [{"Key": "version", "Value": "3.33"}]
    },
]

sns = b3f.contrib.pytest.service_fixture("sns", topics=TOPICS)
```